### PR TITLE
Updated discord CDN location

### DIFF
--- a/lib/ueberauth/strategy/discord.ex
+++ b/lib/ueberauth/strategy/discord.ex
@@ -155,7 +155,7 @@ defmodule Ueberauth.Strategy.Discord do
   end
 
   defp fetch_image(user) do
-    "https://discordcdn.com/avatars/#{user["id"]}/#{user["avatar"]}.jpg"
+    "https://cdn.discordapp.com/avatars/#{user["id"]}/#{user["avatar"]}.jpg"
   end
 
   @doc """


### PR DESCRIPTION
I think discordcdn.com has been removed. I can only ever access images from cdn.discordapp.com so I've changed it here to get the correct image URL.