### PR TITLE
Check for 'prompt' in params

### DIFF
--- a/lib/ueberauth/strategy/discord.ex
+++ b/lib/ueberauth/strategy/discord.ex
@@ -20,6 +20,13 @@ defmodule Ueberauth.Strategy.Discord do
     else
       opts
     end
+
+    opts = if conn.params["prompt"] do
+      Keyword.put(opts, :prompt, conn.params["prompt"])
+    else
+      opts
+    end
+
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
 
     redirect!(conn, Ueberauth.Strategy.Discord.OAuth.authorize_url!(opts))


### PR DESCRIPTION
This partially addresses #4 with allowing the ability to pass in the `prompt` on the request path similar to `scope`.

I was trying to also allow this to be set in the configuration, something like:

```elixir
config :ueberauth, Ueberauth,
  providers: [
    discord: {Ueberauth.Strategy.Discord, [prompt: "none", default_scope: "identify email connections guilds"]}
  ]
```

But I couldn't get `prompt` to properly show up in `handle_request!` via `option(conn, :prompt)`

Closes #4 