### PR TITLE
Replace deprecated calls to filter_map and Dict.get

### DIFF
--- a/lib/ueberauth/strategy/discord.ex
+++ b/lib/ueberauth/strategy/discord.ex
@@ -174,7 +174,9 @@ defmodule Ueberauth.Strategy.Discord do
     if user["avatar"] do
       "https://cdn.discordapp.com/avatars/#{user["id"]}/#{user["avatar"]}.jpg"
     else
-      "https://cdn.discordapp.com/embed/avatars/#{Integer.mod(String.to_integer(user["discriminator"]), 5)}.png"
+      "https://cdn.discordapp.com/embed/avatars/#{
+        Integer.mod(String.to_integer(user["discriminator"]), 5)
+      }.png"
     end
   end
 
@@ -189,14 +191,12 @@ defmodule Ueberauth.Strategy.Discord do
       discord_connections: :connections,
       discord_guilds: :guilds
     }
-    |> Enum.filter_map(
-      fn {original_key, _} ->
-        Map.has_key?(conn.private, original_key)
-      end,
-      fn {original_key, mapped_key} ->
-        {mapped_key, Map.fetch!(conn.private, original_key)}
-      end
-    )
+    |> Enum.filter(fn {original_key, _} ->
+      Map.has_key?(conn.private, original_key)
+    end)
+    |> Enum.map(fn {original_key, mapped_key} ->
+      {mapped_key, Map.fetch!(conn.private, original_key)}
+    end)
     |> Map.new()
     |> (&%Extra{raw_info: &1}).()
   end
@@ -214,6 +214,6 @@ defmodule Ueberauth.Strategy.Discord do
   end
 
   defp option(conn, key) do
-    Dict.get(options(conn), key, Dict.get(default_options(), key))
+    Keyword.get(options(conn), key, Keyword.get(default_options(), key))
   end
 end


### PR DESCRIPTION
I noticed that there were some deprecated calls while working on another pull request.

This is an update that should work fine.