### PR TITLE
Add "permissions" as an optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Depending on the configured url you can initialize the request through:
 
 Or with options:
 
-    /auth/discord?scope=identify%20email
+    /auth/discord?scope=identify%20email&prompt=none&permissions=452987952
 
 By default the requested scope is "identify". Scope can be configured either explicitly as a `scope` query value on the request path or in your configuration:
 
@@ -87,14 +87,15 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
-Additionally you can now specify the `prompt` param to pass to Discord:
+Additionally you can now specify the `prompt` and `permissions` params to pass to Discord:
 
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
     discord: {Ueberauth.Strategy.Discord, [
       default_scope: "identify email connections guilds",
-      prompt: "none"
+      prompt: "none",
+      permissions: 452987952
     ]}
   ]
 ```

--- a/lib/ueberauth/strategy/discord.ex
+++ b/lib/ueberauth/strategy/discord.ex
@@ -14,17 +14,13 @@ defmodule Ueberauth.Strategy.Discord do
   """
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
-    prompt = conn.params["prompt"] || option(conn, :prompt)
-    opts = [scope: scopes, prompt: prompt]
 
     opts =
-      if conn.params["state"] do
-        Keyword.put(opts, :state, conn.params["state"])
-      else
-        opts
-      end
-
-    opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
+      [scope: scopes]
+      |> with_optional_param_or_default(:prompt, conn)
+      |> with_optional_param_or_default(:permissions, conn)
+      |> with_optional_param_or_default(:state, conn)
+      |> Keyword.put(:redirect_uri, callback_url(conn))
 
     redirect!(conn, Ueberauth.Strategy.Discord.OAuth.authorize_url!(opts))
   end
@@ -215,5 +211,17 @@ defmodule Ueberauth.Strategy.Discord do
 
   defp option(conn, key) do
     Dict.get(options(conn), key, Dict.get(default_options(), key))
+
+  defp with_optional_param_or_default(opts, key, conn) do
+    cond do
+      value = conn.params[to_string(key)] ->
+        Keyword.put(opts, key, value)
+
+      default_opt = option(conn, key) ->
+        Keyword.put(opts, key, default_opt)
+
+      true ->
+        opts
+    end
   end
 end


### PR DESCRIPTION
The `permissions` parameter can be used to give permissions to bots.

Here is what bot permissions look like in the discord developers application's page:

![image](https://user-images.githubusercontent.com/1413803/107286211-8ffc1880-6a60-11eb-998a-b32cb48e02b4.png)

[Bot Auth Parameters](https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow-bot-auth-parameters) documentation.