### PR TITLE
CSRF Authorization Error Fix

### DIFF
--- a/lib/ueberauth/strategy/discord.ex
+++ b/lib/ueberauth/strategy/discord.ex
@@ -19,7 +19,7 @@ defmodule Ueberauth.Strategy.Discord do
       [scope: scopes]
       |> with_optional_param_or_default(:prompt, conn)
       |> with_optional_param_or_default(:permissions, conn)
-      |> with_optional_param_or_default(:state, conn)
+      |> Keyword.put(:state, conn.params["state"])
       |> Keyword.put(:redirect_uri, callback_url(conn))
 
     redirect!(conn, Ueberauth.Strategy.Discord.OAuth.authorize_url!(opts))

--- a/lib/ueberauth/strategy/discord.ex
+++ b/lib/ueberauth/strategy/discord.ex
@@ -19,7 +19,7 @@ defmodule Ueberauth.Strategy.Discord do
       [scope: scopes]
       |> with_optional_param_or_default(:prompt, conn)
       |> with_optional_param_or_default(:permissions, conn)
-      |> Keyword.put(:state, conn.params["state"])
+      |> Keyword.put(:state, conn.cookies["ueberauth.state_param"])
       |> Keyword.put(:redirect_uri, callback_url(conn))
 
     redirect!(conn, Ueberauth.Strategy.Discord.OAuth.authorize_url!(opts))


### PR DESCRIPTION
Fixed CSRF authorization error

```
ueberauth_failure: %Ueberauth.Failure{
      errors: [
        %Ueberauth.Failure.Error{
          message: "Cross-Site Request Forgery attack",
          message_key: :csrf_attack
        }
      ],
      provider: :discord,
      strategy: Ueberauth.Strategy.Discord
    }
```