### PR TITLE
Remove old `applications` config from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ For additional documentation on Discord's OAuth implementation see [discord-oaut
     end
     ```
 
-1. Add the strategy to your applications:
-
-    ```elixir
-    def application do
-      [applications: [:ueberauth_discord]]
-    end
-    ```
-
 1. Add Discord to your Überauth configuration:
 
     ```elixir


### PR DESCRIPTION
Elixir/Mix automatically adds ueuberauth_discord to your `applications` when you set it as a dependency. Setting it like suggested overwrites `applications` causing other apps to not be started.